### PR TITLE
WP01: Enemy.Move() implementiert

### DIFF
--- a/TowerDefenseGame/TowerDefenseGame/Models/Enemy.cs
+++ b/TowerDefenseGame/TowerDefenseGame/Models/Enemy.cs
@@ -38,6 +38,24 @@ public class Enemy
 
     public virtual void Move()
     {
+        double dx = PathDefinition.Waypoints[PathDefinition.Waypoints.Count() - 1].X - Position.X;
+        double dy = PathDefinition.Waypoints[PathDefinition.Waypoints.Count() - 1].Y - Position.Y;
+        double distance = Math.Sqrt(dx * dx + dy * dy);
+
+        if (distance < Speed)
+        {
+            _waypointIndex++;
+                if (_waypointIndex >= PathDefinition.Waypoints.Count())
+            {
+                ReachedEnd = true;
+                IsAlive = false;
+                return;
+            }
+        }
+        dx = dx / distance * Speed;
+        dy = dy / distance * Speed;
+        Position = new Point(Position.X + dx, Position.Y + dy);
+
         // TODO (WP1): Bewege den Gegner in Richtung PathDefinition.Waypoints[_waypointIndex].
         //
         // Algorithmus:


### PR DESCRIPTION
This PR simplifies the movement toward the final waypoint.
The entity now moves in the correct direction based on a normalized vector and its speed.
If the entity is close enough to the target, it advances to the next waypoint.
When the last waypoint is reached, the entity is marked as finished.
This prevents overshooting and makes the movement logic clearer.